### PR TITLE
build.py: enable use as a library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ Kamek/*
 *.elf
 helper/*
 /.vs
+__pycache__/
+*.py[cod]
+*$py.clas

--- a/build.py
+++ b/build.py
@@ -9,115 +9,132 @@ def err(message: str):
     print(f"Error: {message}")
     sys.exit(1)
 
+def build(region, includes=["include"]):
+    syati_root = os.path.dirname(__file__)
 
-# Get the target region from the command line
-if len(sys.argv) < 2:
-    err("Did not specify a target region.")
+    # Check if CodeWarrior and Kamek are present in the toolchain
+    command = syati_root + "/CodeWarrior/mwcceppc.exe"
+    if not os.path.exists(command):
+        err("CodeWarrior compiler not found.")
+    asm_cmd = syati_root + "/CodeWarrior/mwasmeppc.exe"
+    if not os.path.exists(asm_cmd):
+        err("CodeWarrior assembler not found.")
+    kamek_cmd = syati_root + "/Kamek/Kamek.exe"
+    if not os.path.exists(kamek_cmd):
+        err("Kamek linker not found.")
 
-region = sys.argv[1]
+    # Define the compiler options and command
+    compiler_options = [
+        "-i .",
+        "-I-"
+    ]
 
-# Check if CodeWarrior and Kamek are present in the toolchain
-if not os.path.exists("CodeWarrior/mwcceppc.exe"):
-    err("CodeWarrior compiler not found.")
-if not os.path.exists("Kamek/Kamek.exe"):
-    err("Kamek linker not found.")
+    for include in includes:
+        compiler_options.append("-i " + include)
 
-# Define the compiler options and command
-compiler_options = [
-    "-i .",
-    "-I-",
-    "-i include",
-    "-nodefaults",
-    "-proc gekko",
-    "-Cpp_exceptions off",
-    "-enum int",
-    "-O4,s",
-    "-fp hard",
-    "-func_align 4",
-    "-str pool",
-    "-sdata 0",
-    "-sdata2 0",
-    f"-D{region}",
-    "-DGEKKO",
-    "-DMTX_USE_PS",
-    "-MMD",
-    "-rtti off",
-    "-c",
-    "-o"
-]
+    assembler_options = compiler_options[:]
 
-assembler_options = [
-    "-i .",
-    "-I-",
-    "-i include",
-    "-proc gekko",
-    "-c",
-    f"-D{region}",
-    "-o"
-]
+    compiler_options += [
+        "-nodefaults",
+        "-proc gekko",
+        "-Cpp_exceptions off",
+        "-enum int",
+        "-O4,s",
+        "-fp hard",
+        "-func_align 4",
+        "-str pool",
+        "-sdata 0",
+        "-sdata2 0",
+        f"-D{region}",
+        "-DGEKKO",
+        "-DMTX_USE_PS",
+        "-MMD",
+        "-rtti off",
+        "-c",
+        "-o"
+    ]
 
-command = "CodeWarrior\mwcceppc.exe " + " ".join(compiler_options)
-asm_cmd = "CodeWarrior\mwasmeppc.exe "  + " ".join(assembler_options)
+    assembler_options += [
+        "-proc gekko",
+        "-c",
+        f"-D{region}",
+        "-o"
+    ]
 
-# Clean the entire build folder first if it exists
-if os.path.exists("build"):
-    shutil.rmtree("build", ignore_errors=True)
+    if os.name != 'nt':
+        command = "wine " + command
+        asm_cmd = "wine " + asm_cmd
+        kamek_cmd = "mono " + kamek_cmd
 
-# Fetch all source C++ files that need to be compiled
-tasks = list()
-asm_tasks = list()
+    command += " " + " ".join(compiler_options)
+    asm_cmd += " " + " ".join(assembler_options)
 
-for root, dirs, files in os.walk("source"):
-    for file in files:
-        if file.endswith(".cpp"):
-            source_path = os.path.join(root, file)
-            build_path = source_path.replace("source", "build").replace(".cpp", ".o")
+    # Clean the entire build folder first if it exists
+    if os.path.exists("build"):
+        shutil.rmtree("build", ignore_errors=True)
 
-            os.makedirs(os.path.dirname(build_path), exist_ok=True)
+    # Fetch all source C++ files that need to be compiled
+    tasks = list()
+    asm_tasks = list()
 
-            tasks.append((source_path, build_path))
-        elif file.endswith(".s"):
-            source_path = os.path.join(root, file)
-            build_path = source_path.replace("source", "build").replace(".s", ".o")
+    for root, dirs, files in os.walk("source"):
+        for file in files:
+            if file.endswith(".cpp"):
+                source_path = os.path.join(root, file)
+                build_path = source_path.replace("source", "build").replace(".cpp", ".o")
 
-            os.makedirs(os.path.dirname(build_path), exist_ok=True)
+                os.makedirs(os.path.dirname(build_path), exist_ok=True)
 
-            asm_tasks.append((source_path, build_path))
+                tasks.append((source_path, build_path))
+            elif file.endswith(".s"):
+                source_path = os.path.join(root, file)
+                build_path = source_path.replace("source", "build").replace(".s", ".o")
 
-if len(tasks) < 1:
-    err("No C++ files to compile!")
+                os.makedirs(os.path.dirname(build_path), exist_ok=True)
+
+                asm_tasks.append((source_path, build_path))
+
+    if len(tasks) < 1:
+        err("No C++ files to compile!")
 
 
-# Process all compile tasks
-for task in tasks:
-    source_path, build_path = task
+    # Process all compile tasks
+    for task in tasks:
+        source_path, build_path = task
 
-    print(f"Compiling {source_path}...")
+        print(f"Compiling {source_path}...")
 
-    if subprocess.call(f"{command} {build_path} {source_path}", shell=True) != 0:
-        err("Compiler error.")
+        if subprocess.call(f"{command} {build_path} {source_path}", shell=True) != 0:
+            err("Compiler error.")
 
-for a_task in asm_tasks:
-    source_path, build_path = a_task
+    for a_task in asm_tasks:
+        source_path, build_path = a_task
 
-    print(f"Assembling {source_path}...")
+        print(f"Assembling {source_path}...")
 
-    if subprocess.call(f"{asm_cmd} {build_path} {source_path}", shell=True) != 0:
-        err("Assembler error.")
+        if subprocess.call(f"{asm_cmd} {build_path} {source_path}", shell=True) != 0:
+            err("Assembler error.")
 
-# Link all object files and create the CustomCode binary
-print("Linking...")
+    # Link all object files and create the CustomCode binary
+    print("Linking...")
 
-object_files = " ".join([task[1] for task in tasks])
-asm_obj_files = " ".join([a_task[1] for a_task in asm_tasks])
+    object_files = " ".join([task[1] for task in tasks])
+    asm_obj_files = " ".join([a_task[1] for a_task in asm_tasks])
 
-kamek_cmd = f"Kamek\Kamek.exe {object_files} {asm_obj_files} -externals=symbols/{region}.txt -output-kamek=CustomCode_{region}.bin"
+    kamek_cmd += f" {object_files} {asm_obj_files} -externals={syati_root}/symbols/{region}.txt -output-kamek=CustomCode_{region}.bin"
 
-if subprocess.call(kamek_cmd, shell=True) != 0:
-    err("Linking failed.")
+    if subprocess.call(kamek_cmd, shell=True) != 0:
+        err("Linking failed.")
 
-# Remove all useless "d" files
-for f in glob.glob("*.d"):
-    os.remove(f)
+    # Remove all useless "d" files
+    for f in glob.glob("*.d"):
+        os.remove(f)
 
-print("Done!")
+    print("Done!")
+
+if __name__ == '__main__':
+    # Get the target region from the command line
+    if len(sys.argv) < 2:
+        err("Did not specify a target region.")
+
+    build(sys.argv[1])


### PR DESCRIPTION
This makes it possible to `import` build.py in another Python program, with the intent of being able to keep Syati in its own directory.

This will not limit any existing use of Syati.